### PR TITLE
Switch CI to upload coverage to Coveralls instead of Codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,9 +85,12 @@ jobs:
           export NREPLICASETS=5
           make test
 
-      - name: Upload coverage reports to Codecov
+      - name: Install goveralls
         if: ${{ matrix.coverage }}
-        uses: codecov/codecov-action@v4.0.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: KaymeKaydex/go-vshard-router
+        run: go install github.com/mattn/goveralls@latest
+
+      - name: Send coverage
+        if: ${{ matrix.coverage }}
+        env:
+          COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: goveralls -coverprofile=coverage.out -service=github

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/tarantool/go-vshard-router.svg)](https://pkg.go.dev/github.com/tarantool/go-vshard-router)
 [![Actions Status][actions-badge]][actions-url]
 [![Go Report Card](https://goreportcard.com/badge/github.com/tarantool/go-vshard-router)](https://goreportcard.com/report/github.com/tarantool/go-vshard-router)
-[![codecov](https://codecov.io/gh/KaymeKaydex/go-vshard-router/graph/badge.svg?token=WLRWE97IT1)](https://codecov.io/gh/KaymeKaydex/go-vshard-router)
+[![Code Coverage][coverage-badge]][coverage-url]
 [![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/KaymeKaydex/go-vshard-router/master/LICENSE)
 
 Translations:
@@ -13,7 +13,7 @@ Translations:
 
 
 go-vshard-router is a library for sending requests to a sharded tarantool cluster directly,
-without using tarantool-router. This library based on [tarantool vhsard library router](https://github.com/tarantool/vshard/blob/master/vshard/router/init.lua). go-vshard-router takes a new approach to creating your cluster
+without using tarantool-router. This library based on [tarantool vhsard library router](https://github.com/tarantool/vshard/blob/master/vshard/router/init.lua) and [go-tarantool connector](https://github.com/tarantool/go-tarantool). go-vshard-router takes a new approach to creating your cluster
 
 Old cluster schema
 ```mermaid
@@ -235,3 +235,5 @@ at a load close to production
 
 [actions-badge]: https://github.com/tarantool/go-vshard-router/actions/workflows/main.yml/badge.svg
 [actions-url]: https://github.com/tarantool/go-vshard-router/actions/workflows/main.yml
+[coverage-badge]: https://coveralls.io/repos/github/tarantool/go-vshard-router/badge.svg?branch=master
+[coverage-url]: https://coveralls.io/github/tarantool/go-vshard-router?branch=master

--- a/README_ru.md
+++ b/README_ru.md
@@ -5,13 +5,14 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/tarantool/go-vshard-router.svg)](https://pkg.go.dev/github.com/tarantool/go-vshard-router)
 [![Actions Status][actions-badge]][actions-url]
 [![Go Report Card](https://goreportcard.com/badge/github.com/tarantool/go-vshard-router)](https://goreportcard.com/report/github.com/tarantool/go-vshard-router)
-[![codecov](https://codecov.io/gh/KaymeKaydex/go-vshard-router/graph/badge.svg?token=WLRWE97IT1)](https://codecov.io/gh/KaymeKaydex/go-vshard-router)
+[![Code Coverage][coverage-badge]][coverage-url]
+[![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/KaymeKaydex/go-vshard-router/master/LICENSE)
 
 Translations:
 - [English](https://github.com/tarantool/go-vshard-router/blob/main/README.md)
 
 go-vshard-router — библиотека для отправки запросов напрямую в стораджа в шардированный кластер tarantool,
-без использования tarantool-router.  Эта библиотека написана на основе [модуля библиотеки tarantool vhsard router](https://github.com/tarantool/vshard/blob/master/vshard/router/init.lua). go-vshard-router применяет новый подход к созданию кластера
+без использования tarantool-router.  Эта библиотека написана на основе [модуля библиотеки tarantool vhsard router](https://github.com/tarantool/vshard/blob/master/vshard/router/init.lua) и [коннектора go-tarantool](https://github.com/tarantool/go-tarantool). go-vshard-router применяет новый подход к созданию кластера
 
 Схема кластера с tarantool-proxy
 ```mermaid
@@ -235,3 +236,5 @@ func main() {
 
 [actions-badge]: https://github.com/tarantool/go-vshard-router/actions/workflows/main.yml/badge.svg
 [actions-url]: https://github.com/tarantool/go-vshard-router/actions/workflows/main.yml
+[coverage-badge]: https://coveralls.io/repos/github/tarantool/go-vshard-router/badge.svg?branch=master
+[coverage-url]: https://coveralls.io/github/tarantool/go-vshard-router?branch=master


### PR DESCRIPTION
Added step to generate coverage profile and configured Coveralls GitHub Action.

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [ ] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
