### PR TITLE
Refactor cluster schema: visualize old and new architectures side by side

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,53 +15,53 @@ Translations:
 go-vshard-router is a library for sending requests to a sharded tarantool cluster directly,
 without using tarantool-router. This library based on [tarantool vhsard library router](https://github.com/tarantool/vshard/blob/master/vshard/router/init.lua) and [go-tarantool connector](https://github.com/tarantool/go-tarantool). go-vshard-router takes a new approach to creating your cluster
 
-Old cluster schema
 ```mermaid
 graph TD
-    subgraph Tarantool Database Cluster
-        subgraph Replicaset 1
-            Master_001_1
-            Replica_001_2
+    %% Old Cluster Schema
+    subgraph Old_Cluster_Schema["Old Cluster Schema"]
+        direction LR
+        subgraph Tarantool Database Cluster
+            subgraph Replicaset 1
+                Master_001_1
+                Replica_001_2
+            end
         end
 
+        ROUTER1["Tarantool vshard-router 1_1"] --> Master_001_1
+        ROUTER2["Tarantool vshard-router 1_2"] --> Master_001_1
+        ROUTER3["Tarantool vshard-router 1_3"] --> Master_001_1
+        ROUTER1["Tarantool vshard-router 1_1"] --> Replica_001_2
+        ROUTER2["Tarantool vshard-router 1_2"] --> Replica_001_2
+        ROUTER3["Tarantool vshard-router 1_3"] --> Replica_001_2
+
+        GO["Golang service"]
+        GO --> ROUTER1
+        GO --> ROUTER2
+        GO --> ROUTER3
     end
 
-ROUTER1["Tarantool vshard-router 1_1"] --> Master_001_1
-ROUTER2["Tarantool vshard-router 1_2"] --> Master_001_1
-ROUTER3["Tarantool vshard-router 1_3"] --> Master_001_1
-ROUTER1["Tarantool vshard-router 1_1"] --> Replica_001_2
-ROUTER2["Tarantool vshard-router 1_2"] --> Replica_001_2
-ROUTER3["Tarantool vshard-router 1_3"] --> Replica_001_2
+    %% New Cluster Schema
+    subgraph New_Cluster_Schema["New Cluster Schema"]
+        direction LR
+        subgraph Application Host
+            Golang_Service
+        end
 
-GO["Golang service"]
-GO --> ROUTER1
-GO --> ROUTER2
-GO --> ROUTER3
-```
-New cluster schema
-```mermaid
-graph TD
-    subgraph Application Host
-        Golang-Service
-    end
+        Golang_Service --> |iproto| MASTER1
+        Golang_Service --> |iproto| REPLICA1
 
-    Golang-Service --> |iproto| MASTER1
-    Golang-Service --> |iproto| REPLICA1
-    
-    MASTER1["Master 001_1"]
-    REPLICA1["Replica 001_2"]
-    
-    subgraph Tarantool Database Cluster
-        subgraph Replicaset 1
-            MASTER1
-            REPLICA1
+        MASTER1["Master 001_1"]
+        REPLICA1["Replica 001_2"]
+
+        subgraph Tarantool Database Cluster
+            subgraph Replicaset 1
+                MASTER1
+                REPLICA1
+            end
         end
     end
-
-    ROUTER1["Tarantool vshard-router(As contorol plane)"]
-    ROUTER1 --> MASTER1
-    ROUTER1 --> REPLICA1
 ```
+
 ## Getting started
 ### Prerequisites
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -14,54 +14,53 @@ Translations:
 go-vshard-router — библиотека для отправки запросов напрямую в стораджа в шардированный кластер tarantool,
 без использования tarantool-router.  Эта библиотека написана на основе [модуля библиотеки tarantool vhsard router](https://github.com/tarantool/vshard/blob/master/vshard/router/init.lua) и [коннектора go-tarantool](https://github.com/tarantool/go-tarantool). go-vshard-router применяет новый подход к созданию кластера
 
-Схема кластера с tarantool-proxy
 ```mermaid
 graph TD
-    subgraph Tarantool Database Cluster
-        subgraph Replicaset 1
-            Master_001_1
-            Replica_001_2
+    %% Старая схема кластера
+    subgraph Old_Cluster_Schema["Old Cluster Schema"]
+        direction LR
+        subgraph Tarantool Database Cluster
+            subgraph Replicaset 1
+                Master_001_1
+                Replica_001_2
+            end
         end
 
+        ROUTER1["Tarantool vshard-router 1_1"] --> Master_001_1
+        ROUTER2["Tarantool vshard-router 1_2"] --> Master_001_1
+        ROUTER3["Tarantool vshard-router 1_3"] --> Master_001_1
+        ROUTER1["Tarantool vshard-router 1_1"] --> Replica_001_2
+        ROUTER2["Tarantool vshard-router 1_2"] --> Replica_001_2
+        ROUTER3["Tarantool vshard-router 1_3"] --> Replica_001_2
+
+        GO["Golang service"]
+        GO --> ROUTER1
+        GO --> ROUTER2
+        GO --> ROUTER3
     end
 
-ROUTER1["Tarantool vshard-router 1_1"] --> Master_001_1
-ROUTER2["Tarantool vshard-router 1_2"] --> Master_001_1
-ROUTER3["Tarantool vshard-router 1_3"] --> Master_001_1
-ROUTER1["Tarantool vshard-router 1_1"] --> Replica_001_2
-ROUTER2["Tarantool vshard-router 1_2"] --> Replica_001_2
-ROUTER3["Tarantool vshard-router 1_3"] --> Replica_001_2
+    %% Новая схема кластера
+    subgraph New_Cluster_Schema["New Cluster Schema"]
+        direction LR
+        subgraph Application Host
+            Golang_Service
+        end
 
-GO["Golang service"]
-GO --> ROUTER1
-GO --> ROUTER2
-GO --> ROUTER3
-```
+        Golang_Service --> |iproto| MASTER1
+        Golang_Service --> |iproto| REPLICA1
 
-Новая схема использования
-```mermaid
-graph TD
-    subgraph Application Host
-        Golang-Service
-    end
+        MASTER1["Master 001_1"]
+        REPLICA1["Replica 001_2"]
 
-    Golang-Service --> |iproto| MASTER1
-    Golang-Service --> |iproto| REPLICA1
-    
-    MASTER1["Master 001_1"]
-    REPLICA1["Replica 001_2"]
-    
-    subgraph Tarantool Database Cluster
-        subgraph Replicaset 1
-            MASTER1
-            REPLICA1
+        subgraph Tarantool Database Cluster
+            subgraph Replicaset 1
+                MASTER1
+                REPLICA1
+            end
         end
     end
-
-    ROUTER1["Tarantool vshard-router(As contorol plane)"]
-    ROUTER1 --> MASTER1
-    ROUTER1 --> REPLICA1
 ```
+
 ## Как начать использовать?
 ### Предварительные условия
 


### PR DESCRIPTION
Displayed the old and new Tarantool cluster architectures on the same level.