### PR TITLE
api: remove RouterMapCallRWImpl method (resolve #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGES:
 * Removed toolchain go1.23.3.
 * Refactored GetTyped interface and logic. Now we use raw msg buffer instead raw messages. Interface works and looks
   like go-tarantool response.
-* ReplicaCall, RouterCallImpl methods was removed cause it works invalid and looks useless.
+* ReplicaCall, RouterCallImpl, RouterMapCallRWImpl methods was removed cause it works invalid and looks useless.
 * All PR, issue references in #XYZ format in commits older than 42f363775dfb9eaf7ec2a6ed7a999847752cec00 refer to https://github.com/KaymeKaydex/go-vshard-router.
 * VshardRouterCallMode type renamed to CallMode for simplicity.
 * StorageResultTypedFunc type removed as useless type.

--- a/api.go
+++ b/api.go
@@ -539,21 +539,6 @@ func (r *storageRefResponseProto) DecodeMsgpack(d *msgpack.Decoder) error {
 	return nil
 }
 
-// RouterMapCallRWImpl perform call function on all masters in the cluster
-// with a guarantee that in case of success it was executed with all
-// buckets being accessible for reads and writes.
-// Deprecated: RouterMapCallRWImpl is deprecated.
-// Use more general RouterMapCallRW instead.
-func (r *Router) RouterMapCallRWImpl(
-	ctx context.Context,
-	fnc string,
-	args interface{},
-	opts CallOpts,
-) (map[string]interface{}, error) {
-	// nolint:gosimple
-	return RouterMapCallRW[interface{}](r, ctx, fnc, args, RouterMapCallRWOptions{Timeout: opts.Timeout})
-}
-
 type replicasetFuture struct {
 	// replicaset name
 	name   string

--- a/tests/tnt/concurrent_topology_test.go
+++ b/tests/tnt/concurrent_topology_test.go
@@ -168,7 +168,7 @@ func TestConncurrentTopologyChange(t *testing.T) {
 			}
 
 			args := []interface{}{"arg1"}
-			_, _ = router.RouterMapCallRWImpl(ctx, "echo", args, vshardrouter.CallOpts{})
+			_, _ = vshardrouter.RouterMapCallRW[interface{}](router, ctx, "echo", args, vshardrouter.RouterMapCallRWOptions{})
 		}
 	}()
 


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

resolve #26

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
