### PR TITLE
make NewRouter tolerant to the cluster's degraded state (resolve #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,15 @@
 BUG FIXES:
 - Fixed go.mod and go.sum files with go mod tidy.
 
+CHANGES:
+* DiscoveryAllBuckets: don't cancel requests to other replicasets if request to some replicaset failed.
+* AddReplicaset: don't fail if there are no available RW instances.
+* NewRouter: don't fail if DiscoveryAllBuckets has returned an error.
+
 TESTS:
 
 - Added etcd v2 provider tests.
+- Add test for degraded cluster (TestDegradedCluster).
 
 ## v2.0.1
 

--- a/discovery.go
+++ b/discovery.go
@@ -222,7 +222,7 @@ func (r *Router) DiscoveryAllBuckets(ctx context.Context) error {
 
 	r.log().Infof(ctx, "Start discovery all buckets")
 
-	errGr, ctx := errgroup.WithContext(ctx)
+	var errGr errgroup.Group
 
 	view := r.getConsistentView()
 	nameToReplicasetRef := r.getNameToReplicaset()
@@ -236,6 +236,7 @@ func (r *Router) DiscoveryAllBuckets(ctx context.Context) error {
 			for {
 				resp, err := rs.bucketsDiscovery(ctx, bucketsDiscoveryPaginationFrom)
 				if err != nil {
+					r.log().Errorf(ctx, "can't bucketsDiscovery for rs %s: %v", rs.info, err)
 					return err
 				}
 

--- a/topology.go
+++ b/topology.go
@@ -130,13 +130,11 @@ func (r *Router) AddReplicaset(ctx context.Context, rsInfo ReplicasetInfo, insta
 		r.log().Infof(ctx, "[replicaset %s ] instance %s %s in role %s", rsInfo, instName, connectStatus, instConnInfo.ConnRole)
 	}
 
-	isConnected, err := conn.ConnectedNow(pool.RW)
-	if err != nil {
-		return fmt.Errorf("cant check rs pool conntected rw now with error: %s", err)
-	}
-
-	if !isConnected {
-		return fmt.Errorf("got connected now as false, storage must be configured first")
+	switch isConnected, err := conn.ConnectedNow(pool.RW); {
+	case err != nil:
+		r.log().Errorf(ctx, "cant check rs pool conntected rw now with error: %v", err)
+	case !isConnected:
+		r.log().Errorf(ctx, "got connected now as false to pool.RW")
 	}
 
 	replicaset.conn = conn

--- a/vshard.go
+++ b/vshard.go
@@ -241,7 +241,7 @@ func NewRouter(ctx context.Context, cfg Config) (*Router, error) {
 
 	err = router.DiscoveryAllBuckets(ctx)
 	if err != nil {
-		return nil, err
+		router.log().Errorf(ctx, "router.DiscoveryAllBuckets failed: %v", err)
 	}
 
 	if cfg.DiscoveryMode == DiscoveryModeOn {
@@ -255,7 +255,7 @@ func NewRouter(ctx context.Context, cfg Config) (*Router, error) {
 		router.cancelDiscovery = cancelFunc
 	}
 
-	return router, err
+	return router, nil
 }
 
 // BucketSet Set a bucket to a replicaset.


### PR DESCRIPTION
make NewRouter tolerant to the cluster's degraded state (resolve #13)

* DiscoveryAllBuckets: don't cancel requests to other replicasets if request to some replicaset failed.
* add test for degraded cluster (TestDegradedCluster)
* AddReplicaset: don't fail if there are no available RW instances
* NewRouter: don't fail if DiscoveryAllBuckets has returned an error

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
