### PR TITLE
Simplify bucket mapping logic

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,7 +45,6 @@ linters:
     - ineffassign
     - revive
     - typecheck
-    - exportloopref
     - prealloc
     # - wls # excluded from linters list because produces too many noise
     - staticcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+CHANGES:
+
+* Bucket mapping code is simplified: (removed consistentView type, removed knownBucketCount field).
+* Remove 'exportloopref' linter because it is no longer relevant.
+
 ## v2.0.3
 
 FEATURES:

--- a/vshard_test.go
+++ b/vshard_test.go
@@ -1,7 +1,6 @@
 package vshard_router //nolint:revive
 
 import (
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,9 +29,6 @@ func TestRouter_RouterBucketCount(t *testing.T) {
 func TestRouter_RouteMapClean(t *testing.T) {
 	r := Router{
 		cfg: Config{TotalBucketCount: 10},
-		view: &consistentView{
-			routeMap: make([]atomic.Pointer[Replicaset], 10),
-		},
 	}
 
 	require.NotPanics(t, func() {


### PR DESCRIPTION
* remove consistentView type
* remove useless knownBucketCount field
* use atomic.Pointer to store routeMap instead of guarding by mutex

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
