### PR TITLE
NewRouter deprecated, cause vshardrouter.New() looks more easy to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 CHANGES:
 
+* NewRouter function is deprecated. Use New instead.
 * Bucket mapping code is simplified: (removed consistentView type, removed knownBucketCount field).
 * Remove 'exportloopref' linter because it is no longer relevant.
 

--- a/vshard.go
+++ b/vshard.go
@@ -193,6 +193,16 @@ func (ii InstanceInfo) Validate() error {
 // -- Configuration
 // --------------------------------------------------------------------------------
 
+// New initializes a new Router instance with the given configuration and context.
+// It prepares the configuration, initializes the topology provider, and performs an initial bucket discovery.
+func New(ctx context.Context, cfg Config) (*Router, error) {
+	return NewRouter(ctx, cfg)
+}
+
+// NewRouter initializes a new Router instance with the given configuration and context.
+// It prepares the configuration, initializes the topology provider, and performs an initial bucket discovery.
+//
+// Deprecated: Use New function instead.
 func NewRouter(ctx context.Context, cfg Config) (*Router, error) {
 	var err error
 


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [ ] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
