### PR TITLE
providers/viper: fix moonlibs convertable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ CHANGES:
 * Bucket mapping code is simplified: (removed consistentView type, removed knownBucketCount field).
 * Remove 'exportloopref' linter because it is no longer relevant.
 
+BUG FIXES:
+
+* Previously the name was not filled for the viper provider for the moonlibs type config. This resulted in incorrect router initialization.
+
 ## v2.0.3
 
 FEATURES:

--- a/providers/viper/moonlibs/convert.go
+++ b/providers/viper/moonlibs/convert.go
@@ -28,7 +28,7 @@ func (cfg *Config) Convert() (map[vshardrouter.ReplicasetInfo][]vshardrouter.Ins
 
 		rsInstances := make([]vshardrouter.InstanceInfo, 0)
 
-		for _, instInfo := range cfg.Topology.Instances {
+		for instName, instInfo := range cfg.Topology.Instances {
 			if instInfo.Cluster != rsName {
 				continue
 			}
@@ -41,6 +41,7 @@ func (cfg *Config) Convert() (map[vshardrouter.ReplicasetInfo][]vshardrouter.Ins
 			}
 
 			rsInstances = append(rsInstances, vshardrouter.InstanceInfo{
+				Name: instName,
 				Addr: instInfo.Box.Listen,
 				UUID: instUUID,
 			})

--- a/providers/viper/moonlibs/convert_test.go
+++ b/providers/viper/moonlibs/convert_test.go
@@ -1,0 +1,43 @@
+package moonlibs
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Convert(t *testing.T) {
+	t.Parallel()
+
+	t.Run("name not empty", func(t *testing.T) {
+		t.Parallel()
+		cfg := Config{Topology: SourceTopologyConfig{
+			Clusters: map[string]ClusterInfo{
+				"cluster_1": {
+					ReplicasetUUID: uuid.New().String(),
+				},
+			},
+			Instances: map[string]InstanceInfo{
+				"instance_1": {
+					Cluster: "cluster_1",
+					Box: struct {
+						Listen       string `json:"listen,omitempty" yaml:"listen" mapstructure:"listen"`
+						InstanceUUID string `yaml:"instance_uuid" mapstructure:"instance_uuid" json:"instanceUUID,omitempty"`
+					}(struct {
+						Listen       string
+						InstanceUUID string
+					}{Listen: "0.0.0.0:1111", InstanceUUID: uuid.New().String()}),
+				},
+			},
+		}}
+
+		m, err := cfg.Convert()
+		require.NoError(t, err)
+
+		for _, instances := range m {
+			require.Len(t, instances, 1)
+			require.NotEmpty(t, instances[0].Name)
+		}
+	})
+}


### PR DESCRIPTION
Previously the name was not filled for the viper provider for the moonlibs type config

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
