### PR TITLE
Router.Route: handle outdated *Replicaset object (resolve #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 ## Unreleased
 
+BUG FIXES:
+* Router.Call bugfix: set destinationName := rs.info.Name if destination exists.
+* Router.Route bugfix: handle outdated *Replicaset object (resolve issue #11).
+
 FEATURES:
 * Now when calling RemoveInstance, if an empty replicaset name is passed, the replicaset will be calculated automatically.
 
 CHANGES:
 * Bump go-tarantool from v2.2.1 to v2.3.0.
+* Make comments more go-style.
+* Router.cronDiscovery: log panic in another goroutine.
 
 TESTS:
 * Fixed etcd overlapping ports.

--- a/vshard.go
+++ b/vshard.go
@@ -42,9 +42,8 @@ type Router struct {
 
 	routeMap atomic.Pointer[routeMap]
 
-	// ----------------------- Map-Reduce -----------------------
-	// Storage Ref ID. It must be unique for each ref request
-	// and therefore is global and monotonically growing.
+	// refID is used for Map-Reduce operation. Since it must be unique (within connection) for each ref request,
+	// we made it global and monotonically growing for each Router instance.
 	refID atomic.Int64
 
 	cancelDiscovery func()


### PR DESCRIPTION
resolve #11 

- Router.Call bugfix: set destinationName := rs.info.Name if destination exists
- Router.Route bugfix: handle outdated *Replicaset object
- make comments more go-style
- Router.cronDiscovery: log panic in another goroutine
- copy maps using copyMap generic

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
