### PR TITLE
Fixed etcd overlapping ports & update go-tarantool to v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+CHANGES:
+* Bump go-tarantool from v2.2.1 to v2.3.0.
+
+TESTS:
+* Fixed etcd overlapping ports.
+
 ## v2.0.4
 
 CHANGES:

--- a/config.lua
+++ b/config.lua
@@ -46,7 +46,6 @@ local cfg = {
           }, -- replicaset #2
      }, -- sharding
      replication_connect_quorum = 0, -- its oke if we havent some replicas
-     work_dir = NAME,
 }
 
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/snksoft/crc v1.1.0
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
-	github.com/tarantool/go-tarantool/v2 v2.2.1
+	github.com/tarantool/go-tarantool/v2 v2.3.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	go.etcd.io/etcd/client/v2 v2.305.17
 	go.etcd.io/etcd/client/v3 v3.5.17

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,8 @@ github.com/tarantool/go-iproto v1.1.0 h1:HULVOIHsiehI+FnHfM7wMDntuzUddO09DKqu2Wn
 github.com/tarantool/go-iproto v1.1.0/go.mod h1:LNCtdyZxojUed8SbOiYHoc3v9NvaZTB7p96hUySMlIo=
 github.com/tarantool/go-tarantool/v2 v2.2.1 h1:ldzMVfkmTuJl4ie3ByMIr+mmPSKDVTcSkN8XlVZEows=
 github.com/tarantool/go-tarantool/v2 v2.2.1/go.mod h1:hKKeZeCP8Y8+U6ZFS32ot1jHV/n4WKVP4fjRAvQznMY=
+github.com/tarantool/go-tarantool/v2 v2.3.0 h1:oLEWqQ5rQGT05JdSPaKXNSJyqCXTN7oDWgS11WPlAgk=
+github.com/tarantool/go-tarantool/v2 v2.3.0/go.mod h1:hKKeZeCP8Y8+U6ZFS32ot1jHV/n4WKVP4fjRAvQznMY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/providers/etcd/provider_test.go
+++ b/providers/etcd/provider_test.go
@@ -155,25 +155,16 @@ func TestProvider_GetTopology(t *testing.T) {
 		require.NoError(t, err)
 
 		// set root paths
-		_, err = kapi.Set(ctx, fmt.Sprintf("%s/%s", dbName, "clusters"), "", &client.SetOptions{Dir: true})
-		require.NoError(t, err)
-		_, err = kapi.Set(ctx, fmt.Sprintf("%s/%s", dbName, "instances"), "", &client.SetOptions{Dir: true})
-		require.NoError(t, err)
+		_, _ = kapi.Set(ctx, fmt.Sprintf("%s/%s", dbName, "clusters"), "", &client.SetOptions{Dir: true})
+		_, _ = kapi.Set(ctx, fmt.Sprintf("%s/%s", dbName, "instances"), "", &client.SetOptions{Dir: true})
 		// set cluster
-		_, err = kapi.Set(ctx, fmt.Sprintf("%s/%s/%s", dbName, "clusters", "userdb"), "", &client.SetOptions{Dir: true})
-		require.NoError(t, err)
+		_, _ = kapi.Set(ctx, fmt.Sprintf("%s/%s/%s", dbName, "clusters", "userdb"), "", &client.SetOptions{Dir: true})
 
-		_, err = kapi.Set(ctx, fmt.Sprintf("%s/%s/%s", dbName, "instances", "userdb_001"), "", &client.SetOptions{Dir: true})
-		require.NoError(t, err)
+		_, _ = kapi.Set(ctx, fmt.Sprintf("%s/%s/%s", dbName, "instances", "userdb_001"), "", &client.SetOptions{Dir: true})
+		_, _ = kapi.Set(ctx, fmt.Sprintf("%s/%s/%s/%s", dbName, "instances", "userdb_001", "cluster"), "userdb", &client.SetOptions{Dir: false})
 
-		_, err = kapi.Set(ctx, fmt.Sprintf("%s/%s/%s/%s", dbName, "instances", "userdb_001", "cluster"), "userdb", &client.SetOptions{Dir: false})
-		require.NoError(t, err)
-
-		_, err = kapi.Set(ctx, fmt.Sprintf("%s/%s/%s/%s", dbName, "instances", "userdb_001", "box"), "", &client.SetOptions{Dir: true})
-		require.NoError(t, err)
-
-		_, err = kapi.Set(ctx, fmt.Sprintf("%s/%s/%s/%s/%s", dbName, "instances", "userdb_001", "box", "listen"), "10.0.1.13:3303", &client.SetOptions{Dir: false})
-		require.NoError(t, err)
+		_, _ = kapi.Set(ctx, fmt.Sprintf("%s/%s/%s/%s", dbName, "instances", "userdb_001", "box"), "", &client.SetOptions{Dir: true})
+		_, _ = kapi.Set(ctx, fmt.Sprintf("%s/%s/%s/%s/%s", dbName, "instances", "userdb_001", "box", "listen"), "10.0.1.13:3303", &client.SetOptions{Dir: false})
 
 		topology, err := p.GetTopology()
 		require.NoError(t, err)

--- a/providers/viper/provider_test.go
+++ b/providers/viper/provider_test.go
@@ -100,11 +100,11 @@ func TestNewProvider_ETCD3(t *testing.T) {
 	config.Name = "localhost"
 	config.Dir = "/tmp/my-embedded-ectd-cluster"
 
-	config.ListenPeerUrls = parseEtcdUrls([]string{"http://0.0.0.0:2380"})
-	config.ListenClientUrls = parseEtcdUrls([]string{"http://0.0.0.0:2379"})
-	config.AdvertisePeerUrls = parseEtcdUrls([]string{"http://localhost:2380"})
-	config.AdvertiseClientUrls = parseEtcdUrls([]string{"http://localhost:2379"})
-	config.InitialCluster = "localhost=http://localhost:2380"
+	config.ListenPeerUrls = parseEtcdUrls([]string{"http://0.0.0.0:2480"})
+	config.ListenClientUrls = parseEtcdUrls([]string{"http://0.0.0.0:2479"})
+	config.AdvertisePeerUrls = parseEtcdUrls([]string{"http://localhost:2480"})
+	config.AdvertiseClientUrls = parseEtcdUrls([]string{"http://localhost:2479"})
+	config.InitialCluster = "localhost=http://localhost:2480"
 	config.LogLevel = "panic"
 
 	etcd, err := embed.StartEtcd(config)
@@ -113,7 +113,7 @@ func TestNewProvider_ETCD3(t *testing.T) {
 	defer etcd.Close()
 
 	client, err := clientv3.New(clientv3.Config{
-		Endpoints: []string{"localhost:2379"},
+		Endpoints: []string{"localhost:2479"},
 	})
 	require.NoError(t, err)
 
@@ -134,7 +134,7 @@ func TestNewProvider_ETCD3(t *testing.T) {
 
 	t.Run("ok reads config", func(t *testing.T) {
 		etcdViper := viper.New()
-		err = etcdViper.AddRemoteProvider("etcd3", "http://127.0.0.1:2379", key)
+		err = etcdViper.AddRemoteProvider("etcd3", "http://127.0.0.1:2479", key)
 		require.NoError(t, err)
 
 		etcdViper.SetConfigType("yaml")
@@ -148,7 +148,7 @@ func TestNewProvider_ETCD3(t *testing.T) {
 	t.Run("invalid path", func(t *testing.T) {
 		etcdViper := viper.New()
 
-		err = etcdViper.AddRemoteProvider("etcd3", "http://127.0.0.1:2379", "/some-invalid-path")
+		err = etcdViper.AddRemoteProvider("etcd3", "http://127.0.0.1:2479", "/some-invalid-path")
 		require.NoError(t, err)
 
 		etcdViper.SetConfigType("yaml")
@@ -165,7 +165,7 @@ func TestNewProvider_ETCD3(t *testing.T) {
 		_, err := kv.Put(ctx, emptyPath, "")
 		require.NoError(t, err)
 
-		err = etcdViper.AddRemoteProvider("etcd3", "http://127.0.0.1:2379", "/some-empty-path")
+		err = etcdViper.AddRemoteProvider("etcd3", "http://127.0.0.1:2479", "/some-empty-path")
 		require.NoError(t, err)
 
 		etcdViper.SetConfigType("yaml")

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -867,11 +867,11 @@ func runTestMain(m *testing.M) int {
 		RetryTimeout: 500 * time.Millisecond,
 		WorkDir:      "router",
 	})
-
 	if err != nil {
 		log.Printf("Failed to prepare test Tarantool: %s", err)
 		return 1
 	}
+	time.Sleep(time.Second / 2) // force await bootstrap
 
 	defer test_helpers.StopTarantoolWithCleanup(inst)
 	defer test_helpers.StopTarantoolInstances(instances)

--- a/test_helper/helper.go
+++ b/test_helper/helper.go
@@ -8,9 +8,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func StartTarantoolInstances(instsOpts []ttnt.StartOpts) ([]ttnt.TarantoolInstance, error) {
+func StartTarantoolInstances(instsOpts []ttnt.StartOpts) ([]*ttnt.TarantoolInstance, error) {
 	ctx := context.Background()
-	instances := make([]ttnt.TarantoolInstance, len(instsOpts))
+	instances := make([]*ttnt.TarantoolInstance, len(instsOpts))
 	errGr, _ := errgroup.WithContext(ctx)
 
 	for i, opts := range instsOpts {


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [ ] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
