### PR TITLE
SlogLoggerf: don't fmt.Sprintf if logLevel is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGES:
 * Bump go-tarantool from v2.2.1 to v2.3.0.
 * Make comments more go-style.
 * Router.cronDiscovery: log panic in another goroutine.
+* Tiny optimization in SlogLoggerf.
 
 TESTS:
 * Fixed etcd overlapping ports.

--- a/providers.go
+++ b/providers.go
@@ -101,21 +101,33 @@ type SlogLoggerf struct {
 
 // Debugf implements Debugf method for LogfProvider interface
 func (s *SlogLoggerf) Debugf(ctx context.Context, format string, v ...any) {
+	if !s.Logger.Enabled(ctx, slog.LevelDebug) {
+		return
+	}
 	s.Logger.DebugContext(ctx, fmt.Sprintf(format, v...))
 }
 
 // Infof implements Infof method for LogfProvider interface
 func (s SlogLoggerf) Infof(ctx context.Context, format string, v ...any) {
+	if !s.Logger.Enabled(ctx, slog.LevelInfo) {
+		return
+	}
 	s.Logger.InfoContext(ctx, fmt.Sprintf(format, v...))
 }
 
 // Warnf implements Warnf method for LogfProvider interface
 func (s SlogLoggerf) Warnf(ctx context.Context, format string, v ...any) {
+	if !s.Logger.Enabled(ctx, slog.LevelWarn) {
+		return
+	}
 	s.Logger.WarnContext(ctx, fmt.Sprintf(format, v...))
 }
 
 // Errorf implements Errorf method for LogfProvider interface
 func (s SlogLoggerf) Errorf(ctx context.Context, format string, v ...any) {
+	if !s.Logger.Enabled(ctx, slog.LevelError) {
+		return
+	}
 	s.Logger.ErrorContext(ctx, fmt.Sprintf(format, v...))
 }
 


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
