### PR TITLE
proto: more strict check of vshard.storage.call response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGES:
 * Tiny optimization in SlogLoggerf.
 * The MetricsProvider interface has been made experimental. This means that during the release we may change its implementation. If you do not want to lose backward compatibility, use empty or the standard prometheus implementation.
 * RequestDuration metric interface requires procedure name.
+* More strict check of vshard.storage.call response.
 
 TESTS:
 * Fixed etcd overlapping ports.

--- a/replicaset.go
+++ b/replicaset.go
@@ -101,8 +101,8 @@ func (r *vshardStorageBucketStatResponseProto) DecodeMsgpack(d *msgpack.Decoder)
 		return err
 	}
 
-	if respArrayLen == 0 {
-		return fmt.Errorf("protocol violation bucketStatWait: empty response")
+	if respArrayLen <= 0 {
+		return fmt.Errorf("protocol violation bucketStatWait: respArrayLen=%d", respArrayLen)
 	}
 
 	code, err := d.PeekCode()


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
