### PR TITLE
Moved slog logger implementation to providers/slog directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+CHANGES:
+* Slog provider moved to providers directory.
+
 ## v2.0.5
 
 The go-vshard team apologizes for changing the interfaces to experimental status.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ This will allow you not to think about options and metrics settings.
 The following providers are currently available:
 - **[prometheus](providers/prometheus)**
 
+#### Logs
+
+- stdout (builtin)
+- **[slog](providers/slog)**
+
 ### Learn more examples
 #### Quick Start
 Learn with th [Quick Start](docs/doc.md), which include  examples and theory.

--- a/README_ru.md
+++ b/README_ru.md
@@ -208,6 +208,12 @@ func main() {
 На данный момент доступны следующие провайдеры:
 - **[prometheus](providers/prometheus)**
 
+#### Логирование
+
+- stdout (builtin)
+- **[slog](providers/slog)**
+
+
 ### Ознакомьтесь с другими примерами
 
 #### Быстрое начало

--- a/providers.go
+++ b/providers.go
@@ -2,9 +2,7 @@ package vshard_router //nolint:revive
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"log/slog"
 	"time"
 )
 
@@ -15,7 +13,6 @@ var (
 	// Ensure StdoutLoggerf implements LogfProvider
 	_ LogfProvider = StdoutLoggerf{}
 	// Ensure SlogLoggerf implements LogfProvider
-	_ LogfProvider = &SlogLoggerf{}
 )
 
 // LogfProvider an interface to inject a custom logger.
@@ -85,50 +82,6 @@ func (s StdoutLoggerf) Warnf(_ context.Context, format string, v ...any) {
 // Errorf implements Errorf method for LogfProvider interface
 func (s StdoutLoggerf) Errorf(_ context.Context, format string, v ...any) {
 	s.printLevel(StdoutLogError, "[ERROR] ", format, v...)
-}
-
-// NewSlogLogger wraps slog logger
-func NewSlogLogger(logger *slog.Logger) LogfProvider {
-	return &SlogLoggerf{
-		Logger: logger,
-	}
-}
-
-// SlogLoggerf is adapter for slog to Logger interface.
-type SlogLoggerf struct {
-	Logger *slog.Logger
-}
-
-// Debugf implements Debugf method for LogfProvider interface
-func (s *SlogLoggerf) Debugf(ctx context.Context, format string, v ...any) {
-	if !s.Logger.Enabled(ctx, slog.LevelDebug) {
-		return
-	}
-	s.Logger.DebugContext(ctx, fmt.Sprintf(format, v...))
-}
-
-// Infof implements Infof method for LogfProvider interface
-func (s SlogLoggerf) Infof(ctx context.Context, format string, v ...any) {
-	if !s.Logger.Enabled(ctx, slog.LevelInfo) {
-		return
-	}
-	s.Logger.InfoContext(ctx, fmt.Sprintf(format, v...))
-}
-
-// Warnf implements Warnf method for LogfProvider interface
-func (s SlogLoggerf) Warnf(ctx context.Context, format string, v ...any) {
-	if !s.Logger.Enabled(ctx, slog.LevelWarn) {
-		return
-	}
-	s.Logger.WarnContext(ctx, fmt.Sprintf(format, v...))
-}
-
-// Errorf implements Errorf method for LogfProvider interface
-func (s SlogLoggerf) Errorf(ctx context.Context, format string, v ...any) {
-	if !s.Logger.Enabled(ctx, slog.LevelError) {
-		return
-	}
-	s.Logger.ErrorContext(ctx, fmt.Sprintf(format, v...))
 }
 
 // Metrics

--- a/providers/slog/slog.go
+++ b/providers/slog/slog.go
@@ -1,0 +1,56 @@
+package slog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	vshardrouter "github.com/tarantool/go-vshard-router/v2"
+)
+
+// Check that provider implements LogfProvider interface.
+var _ vshardrouter.LogfProvider = (*SlogLoggerf)(nil)
+
+// NewSlogLogger wraps slog logger for go-vshard-router.
+func NewSlogLogger(logger *slog.Logger) *SlogLoggerf {
+	return &SlogLoggerf{
+		Logger: logger,
+	}
+}
+
+// SlogLoggerf is adapter for slog to Logger interface.
+type SlogLoggerf struct {
+	Logger *slog.Logger
+}
+
+// Debugf implements Debugf method for LogfProvider interface
+func (s *SlogLoggerf) Debugf(ctx context.Context, format string, v ...any) {
+	if !s.Logger.Enabled(ctx, slog.LevelDebug) {
+		return
+	}
+	s.Logger.DebugContext(ctx, fmt.Sprintf(format, v...))
+}
+
+// Infof implements Infof method for LogfProvider interface
+func (s *SlogLoggerf) Infof(ctx context.Context, format string, v ...any) {
+	if !s.Logger.Enabled(ctx, slog.LevelInfo) {
+		return
+	}
+	s.Logger.InfoContext(ctx, fmt.Sprintf(format, v...))
+}
+
+// Warnf implements Warnf method for LogfProvider interface
+func (s *SlogLoggerf) Warnf(ctx context.Context, format string, v ...any) {
+	if !s.Logger.Enabled(ctx, slog.LevelWarn) {
+		return
+	}
+	s.Logger.WarnContext(ctx, fmt.Sprintf(format, v...))
+}
+
+// Errorf implements Errorf method for LogfProvider interface
+func (s *SlogLoggerf) Errorf(ctx context.Context, format string, v ...any) {
+	if !s.Logger.Enabled(ctx, slog.LevelError) {
+		return
+	}
+	s.Logger.ErrorContext(ctx, fmt.Sprintf(format, v...))
+}

--- a/providers/slog/slog_test.go
+++ b/providers/slog/slog_test.go
@@ -1,0 +1,52 @@
+package slog
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	vshardrouter "github.com/tarantool/go-vshard-router/v2"
+)
+
+func TestNewSlogLogger(t *testing.T) {
+	var slogProvider vshardrouter.LogfProvider
+
+	require.NotPanics(t, func() {
+		slogProvider = NewSlogLogger(nil)
+	})
+
+	require.Panics(t, func() {
+		slogProvider.Warnf(context.TODO(), "")
+	})
+}
+
+func TestSlogProvider(t *testing.T) {
+	ctx := context.Background()
+
+	// create new logger handler
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelError,
+	})
+	// create new SLogger instance
+	sLogger := slog.New(handler)
+
+	logProvider := NewSlogLogger(sLogger)
+
+	require.NotPanics(t, func() {
+		logProvider.Infof(ctx, "test %s", "s")
+	})
+
+	require.NotPanics(t, func() {
+		logProvider.Warnf(ctx, "test %s", "s")
+	})
+
+	require.NotPanics(t, func() {
+		logProvider.Errorf(ctx, "test %s", "s")
+	})
+
+	require.NotPanics(t, func() {
+		logProvider.Debugf(ctx, "test %s", "s")
+	})
+}

--- a/providers_test.go
+++ b/providers_test.go
@@ -2,8 +2,6 @@ package vshard_router_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
 	"testing"
 	"time"
 
@@ -49,46 +47,5 @@ func TestStdoutLogger(t *testing.T) {
 	})
 	require.NotPanics(t, func() {
 		stdoutLogger.Debugf(ctx, "")
-	})
-}
-
-func TestNewSlogLogger(t *testing.T) {
-	var slogProvider vshardrouter.LogfProvider
-
-	require.NotPanics(t, func() {
-		slogProvider = vshardrouter.NewSlogLogger(nil)
-	})
-
-	require.Panics(t, func() {
-		slogProvider.Warnf(context.TODO(), "")
-	})
-}
-
-func TestSlogProvider(t *testing.T) {
-	ctx := context.Background()
-
-	// create new logger handler
-	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelError,
-	})
-	// create new SLogger instance
-	sLogger := slog.New(handler)
-
-	logProvider := vshardrouter.NewSlogLogger(sLogger)
-
-	require.NotPanics(t, func() {
-		logProvider.Infof(ctx, "test %s", "s")
-	})
-
-	require.NotPanics(t, func() {
-		logProvider.Warnf(ctx, "test %s", "s")
-	})
-
-	require.NotPanics(t, func() {
-		logProvider.Errorf(ctx, "test %s", "s")
-	})
-
-	require.NotPanics(t, func() {
-		logProvider.Debugf(ctx, "test %s", "s")
 	})
 }


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [ ] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
