### PR TITLE
Router.Call: add pause before rerying r.Route (resolve #66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGES:
 * More strict check of vshard.storage.call response.
 * Bump go-tarantool from v2.3.0 to v2.3.1.
 * Get rid of nameToReplicasetMutex, use atomic instead.
+* Add configurable pause before retrying r.Route in Router.Call method.
 
 ## v2.0.5
 


### PR DESCRIPTION
What has been done? Why? What problem is being solved?
Resolve #66 

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
