### PR TITLE
Bump go-tarantool from v2.3.0 to v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 CHANGES:
 * Slog provider moved to providers directory.
 * More strict check of vshard.storage.call response.
+* Bump go-tarantool from v2.3.0 to v2.3.1.
 
 ## v2.0.5
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/snksoft/crc v1.1.0
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
-	github.com/tarantool/go-tarantool/v2 v2.3.0
+	github.com/tarantool/go-tarantool/v2 v2.3.1
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	go.etcd.io/etcd/client/v2 v2.305.17
 	go.etcd.io/etcd/client/v3 v3.5.17

--- a/go.sum
+++ b/go.sum
@@ -352,6 +352,8 @@ github.com/tarantool/go-tarantool/v2 v2.2.1 h1:ldzMVfkmTuJl4ie3ByMIr+mmPSKDVTcSk
 github.com/tarantool/go-tarantool/v2 v2.2.1/go.mod h1:hKKeZeCP8Y8+U6ZFS32ot1jHV/n4WKVP4fjRAvQznMY=
 github.com/tarantool/go-tarantool/v2 v2.3.0 h1:oLEWqQ5rQGT05JdSPaKXNSJyqCXTN7oDWgS11WPlAgk=
 github.com/tarantool/go-tarantool/v2 v2.3.0/go.mod h1:hKKeZeCP8Y8+U6ZFS32ot1jHV/n4WKVP4fjRAvQznMY=
+github.com/tarantool/go-tarantool/v2 v2.3.1 h1:Man7wssU7hpzqj6pEJwaLhpuR1rk5aguwafHrrh3sHk=
+github.com/tarantool/go-tarantool/v2 v2.3.1/go.mod h1:MTbhdjFc3Jl63Lgi/UJr5D+QbT+QegqOzsNJGmaw7VM=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [ ] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
