### PR TITLE
Add replicaset name to metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ CHANGES:
 * Bump go-tarantool from v2.3.0 to v2.3.1.
 * Get rid of nameToReplicasetMutex, use atomic instead.
 * Add configurable pause before retrying r.Route in Router.Call method.
+* Metrics provider now requires replicaset name.
+
+FEATURES:
+* Add replicaset name support for prometheus provider.
 
 ## v2.0.5
 

--- a/api.go
+++ b/api.go
@@ -281,7 +281,7 @@ func (r *Router) Call(ctx context.Context, bucketID uint64, mode CallMode,
 
 	for {
 		if spent := time.Since(requestStartTime); spent > timeout {
-			r.metrics().RequestDuration(spent, fnc, false, false)
+			r.metrics().RequestDuration(spent, fnc, "", false, false)
 
 			r.log().Debugf(ctx, "Return result on timeout; spent %s of timeout %s", spent, timeout)
 			if err == nil {
@@ -407,7 +407,7 @@ func (r *Router) Call(ctx context.Context, bucketID uint64, mode CallMode,
 			}
 		}
 
-		r.metrics().RequestDuration(time.Since(requestStartTime), fnc, true, false)
+		r.metrics().RequestDuration(time.Since(requestStartTime), fnc, rs.info.Name, true, false)
 
 		return storageCallResponse.CallResp, nil
 	}
@@ -681,7 +681,7 @@ func RouterMapCallRW[T any](r *Router, ctx context.Context,
 		nameToResult[rsFuture.name] = storageMapResponse.value
 	}
 
-	r.metrics().RequestDuration(time.Since(timeStart), fnc, true, true)
+	r.metrics().RequestDuration(time.Since(timeStart), fnc, "all", true, true)
 
 	return nameToResult, nil
 }

--- a/providers.go
+++ b/providers.go
@@ -91,16 +91,16 @@ func (s StdoutLoggerf) Errorf(_ context.Context, format string, v ...any) {
 type MetricsProvider interface {
 	CronDiscoveryEvent(ok bool, duration time.Duration, reason string)
 	RetryOnCall(reason string)
-	RequestDuration(duration time.Duration, procedure string, ok, mapReduce bool)
+	RequestDuration(duration time.Duration, procedure, rsName string, ok, mapReduce bool)
 }
 
 // EmptyMetrics is default empty metrics provider
 // you can embed this type and realize just some metrics
 type EmptyMetrics struct{}
 
-func (e *EmptyMetrics) CronDiscoveryEvent(_ bool, _ time.Duration, _ string) {}
-func (e *EmptyMetrics) RetryOnCall(_ string)                                 {}
-func (e *EmptyMetrics) RequestDuration(_ time.Duration, _ string, _, _ bool) {}
+func (e *EmptyMetrics) CronDiscoveryEvent(_ bool, _ time.Duration, _ string)    {}
+func (e *EmptyMetrics) RetryOnCall(_ string)                                    {}
+func (e *EmptyMetrics) RequestDuration(_ time.Duration, _, _ string, _, _ bool) {}
 
 // TopologyProvider is external module that can lookup current topology of cluster
 // it might be etcd/config/consul or smth else

--- a/providers/prometheus/prometheus.go
+++ b/providers/prometheus/prometheus.go
@@ -55,11 +55,12 @@ func (pp *Provider) RetryOnCall(reason string) {
 }
 
 // RequestDuration records the duration of a request with labels for success and map-reduce usage.
-func (pp *Provider) RequestDuration(duration time.Duration, procedure string, ok, mapReduce bool) {
+func (pp *Provider) RequestDuration(duration time.Duration, procedure, rsName string, ok, mapReduce bool) {
 	pp.requestDuration.With(prometheus.Labels{
 		"ok":         strconv.FormatBool(ok),
 		"map_reduce": strconv.FormatBool(mapReduce),
 		"procedure":  procedure,
+		"replicaset": rsName,
 	}).Observe(float64(duration.Milliseconds()))
 }
 
@@ -98,6 +99,6 @@ func NewPrometheusProvider() *Provider {
 		requestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:      "request_duration",
 			Namespace: "vshard",
-		}, []string{"procedure", "ok", "map_reduce"}), // Histogram for request durations
+		}, []string{"procedure", "ok", "map_reduce", "replicaset"}), // Histogram for request durations
 	}
 }

--- a/providers/prometheus/prometheus_example_test.go
+++ b/providers/prometheus/prometheus_example_test.go
@@ -35,7 +35,7 @@ func ExampleNewPrometheusProvider() {
 
 	provider.CronDiscoveryEvent(true, 150*time.Millisecond, "success")
 	provider.RetryOnCall("timeout")
-	provider.RequestDuration(200*time.Millisecond, "test", true, false)
+	provider.RequestDuration(200*time.Millisecond, "test", "test-rs", true, false)
 
 	resp, err := http.Get(server.URL + "/metrics")
 	if err != nil {

--- a/providers/prometheus/prometheus_test.go
+++ b/providers/prometheus/prometheus_test.go
@@ -23,7 +23,7 @@ func TestPrometheusMetricsServer(t *testing.T) {
 
 	provider.CronDiscoveryEvent(true, 150*time.Millisecond, "success")
 	provider.RetryOnCall("timeout")
-	provider.RequestDuration(200*time.Millisecond, "test", true, false)
+	provider.RequestDuration(200*time.Millisecond, "test", "test-rs", true, false)
 
 	resp, err := http.Get(server.URL + "/metrics")
 	require.NoError(t, err)

--- a/providers_test.go
+++ b/providers_test.go
@@ -23,7 +23,7 @@ func TestEmptyMetrics_RetryOnCall(t *testing.T) {
 
 func TestEmptyMetrics_RequestDuration(t *testing.T) {
 	require.NotPanics(t, func() {
-		emptyMetrics.RequestDuration(time.Second, "test", false, false)
+		emptyMetrics.RequestDuration(time.Second, "test", "test-rs", false, false)
 	})
 }
 


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

No we support replicaset name and can watch on replicaset metrics

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
