### PR TITLE
bugfix: do not flush out routeMap in bucketSearchBatched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ CHANGES:
 * Add ability to set custom dialer in InstaceInfo.
 * Router.Call: retry on VShardErrNameTransferIsInProgress error as in the `vshard` module (#75).
 
+BUG FIXES:
+* Router.bucketSearchBatched: do not flush out routeMap (#79).
+
 ## v2.0.5
 
 The go-vshard team apologizes for changing the interfaces to experimental status.

--- a/discovery.go
+++ b/discovery.go
@@ -169,7 +169,7 @@ func (r *Router) bucketSearchBatched(ctx context.Context, bucketIDToFind uint64)
 				rs = rsFuture.rs
 			}
 
-			routeMap[bucketID].Store(rs)
+			routeMap[bucketID].Store(rsFuture.rs)
 		}
 
 		if bucketIDWasFound := rs != nil; !bucketIDWasFound {


### PR DESCRIPTION
While handling bucketsDiscoveryWait response,
we wrongly store nil pointer for received bucketIDs
if the target bucketID does not belong to a replicaset,
whose response is being processed.

Closes #79

Unfortunately, no new tests are provided due to limitations of the current testing module.

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
